### PR TITLE
Fix auto restart when out of moves

### DIFF
--- a/Nintai/Views/GameView.swift
+++ b/Nintai/Views/GameView.swift
@@ -158,7 +158,6 @@ struct GameView: View {
             }
             .onAppear {
                 calculateCardSize(geometry: geometry)
-                gameState.newGame()
             }
             .onChange(of: geometry.size) { _, _ in
                 calculateCardSize(geometry: geometry)


### PR DESCRIPTION
## Summary
- avoid calling `newGame()` on every appearance of `GameView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687d661415ec8322a7a1bc6010f54ebe