### PR TITLE
Enable tap-to-move cards

### DIFF
--- a/Nintai.xcodeproj/project.pbxproj
+++ b/Nintai.xcodeproj/project.pbxproj
@@ -408,7 +408,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+                               MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = pb.Nintai;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -441,7 +441,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+                               MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = pb.Nintai;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
## Summary
- allow tapping foundations or tableau columns to receive a selected card
- support selecting waste and tableau cards via tap
- offset selected cards when tapped so they float
- show dragged card stack only while dragging
- bump marketing version to 1.3

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6882dfa0b3c08322ad35b485a9be7165