### PR TITLE
Fix card selection scaling

### DIFF
--- a/Nintai/Views/GameView.swift
+++ b/Nintai/Views/GameView.swift
@@ -336,7 +336,7 @@ struct GameView: View {
                         let isSelected = !isDragging && selectedFromColumn == -1 && selectedCard?.id == card.id
 
                         CardView(card: card, width: cardWidth, height: cardHeight)
-                            .offset(x: CGFloat(index) * 25, y: isSelected ? -20 : 0)
+                            .offset(x: CGFloat(index) * 25)
                             .zIndex(Double(index))
                             .scaleEffect(isBeingDragged ? 1.05 : (isSelected ? 1.1 : 1.0))
                             .opacity(isBeingDragged && isDragging ? 0 : 1)
@@ -415,7 +415,7 @@ struct GameView: View {
                     .zIndex(Double(cardIndex))
                     .scaleEffect(isPartOfDraggedStack ? 1.05 : (isPartOfSelectedStack ? 1.1 : 1.0))
                     .opacity(isPartOfDraggedStack && isDragging ? 0 : 1)
-                    .offset(y: offset + (isPartOfSelectedStack ? -20 : 0))
+                    .offset(y: offset)
                     .gesture(
                         DragGesture(minimumDistance: 5, coordinateSpace: .global)
                             .onChanged { value in
@@ -441,7 +441,9 @@ struct GameView: View {
                             guard !isDragging else { return }
 
                             if let selected = selectedCard {
-                                if selected.id == card.id && selectedFromColumn == columnIndex {
+                                if selectedFromColumn == columnIndex,
+                                   let selectedIndex = selectedCardIndex,
+                                   cardIndex >= selectedIndex {
                                     clearSelection()
                                 } else {
                                     _ = tryMoveToTableau(selectedCard: selected, columnIndex: columnIndex)
@@ -465,8 +467,12 @@ struct GameView: View {
         .simultaneousGesture(
             TapGesture().onEnded {
                 if !isDragging, let selected = selectedCard {
-                    _ = tryMoveToTableau(selectedCard: selected, columnIndex: columnIndex)
-                    clearSelection()
+                    if selectedFromColumn == columnIndex {
+                        clearSelection()
+                    } else {
+                        _ = tryMoveToTableau(selectedCard: selected, columnIndex: columnIndex)
+                        clearSelection()
+                    }
                 }
             }
         )


### PR DESCRIPTION
## Summary
- remove Y-offset for selected waste pile cards
- keep tableau cards in place and only enlarge when selected
- allow deselecting a selected tableau stack by tapping on it again

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6883163774748322b8d25767a6c16f03