### PR TITLE
Fix black screen after start animation

### DIFF
--- a/Nintai/Views/GameView.swift
+++ b/Nintai/Views/GameView.swift
@@ -699,6 +699,9 @@ struct GameView: View {
 
     private func startDealAnimation() {
         isDealing = true
+        withAnimation(.easeIn(duration: 0.2)) {
+            showGameContent = true
+        }
         var delay: Double = 0
         let step: Double = 0.08
 


### PR DESCRIPTION
## Summary
- show game content when deal animation starts

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688413c58fe883228bf3afc43538ab7c