### PR TITLE
Add card flip animation

### DIFF
--- a/Nintai/Models/GameState.swift
+++ b/Nintai/Models/GameState.swift
@@ -123,9 +123,8 @@ class GameState: ObservableObject {
         tableau[sourceColumn].removeLast(cardsToMove.count)
         tableau[destColumn].append(contentsOf: cardsToMove)
         
-        if let lastCard = tableau[sourceColumn].last, !lastCard.isFaceUp {
-            let faceUpCard = Card(suit: lastCard.suit, rank: lastCard.rank, isFaceUp: true)
-            tableau[sourceColumn][tableau[sourceColumn].count - 1] = faceUpCard
+        if !tableau[sourceColumn].isEmpty && !tableau[sourceColumn].last!.isFaceUp {
+            tableau[sourceColumn][tableau[sourceColumn].count - 1].isFaceUp = true
         }
         
         moves += 1

--- a/Nintai/Views/GameView.swift
+++ b/Nintai/Views/GameView.swift
@@ -669,9 +669,8 @@ struct GameView: View {
                     if let fromIndex = selectedCardIndex {
                         gameState.tableau[fromColumn].removeLast(gameState.tableau[fromColumn].count - fromIndex)
                         // Flip the next card if needed
-                        if let lastCard = gameState.tableau[fromColumn].last, !lastCard.isFaceUp {
-                            let faceUpCard = Card(suit: lastCard.suit, rank: lastCard.rank, isFaceUp: true)
-                            gameState.tableau[fromColumn][gameState.tableau[fromColumn].count - 1] = faceUpCard
+                        if !gameState.tableau[fromColumn].isEmpty && !gameState.tableau[fromColumn].last!.isFaceUp {
+                            gameState.tableau[fromColumn][gameState.tableau[fromColumn].count - 1].isFaceUp = true
                             HapticManager.shared.cardFlip()
                         }
                     }


### PR DESCRIPTION
## Summary
- keep card IDs when revealing cards in tableau
- animate card flip with 3D rotation and lift effect
- update flip logic when moving to foundation

## Testing
- `swiftc -dump-ast Nintai/Views/CardView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68841a089f3883228fcb7eaf1e31a837