### PR TITLE
Fix move stats update

### DIFF
--- a/Nintai/Models/GameState.swift
+++ b/Nintai/Models/GameState.swift
@@ -68,6 +68,7 @@ class GameState: ObservableObject {
             waste.append(faceUpCard)
         }
         moves += 1
+        GameStats.shared.recordMove()
         saveGameState()
         
         Task {
@@ -112,6 +113,7 @@ class GameState: ObservableObject {
         objectWillChange.send()
         foundations[foundationIndex].append(card)
         moves += 1
+        GameStats.shared.recordMove()
         saveGameState()
         checkForWin()
         
@@ -133,6 +135,7 @@ class GameState: ObservableObject {
         }
         
         moves += 1
+        GameStats.shared.recordMove()
         saveGameState()
         
         Task {
@@ -291,6 +294,7 @@ class GameState: ObservableObject {
                             tableau[colIndex].removeLast()
                             foundations[foundIndex].append(topCard)
                             moves += 1
+                            GameStats.shared.recordMove()
                             saveGameState()
                             checkForWin()
                             
@@ -311,6 +315,7 @@ class GameState: ObservableObject {
                         waste.removeLast()
                         foundations[foundIndex].append(topWasteCard)
                         moves += 1
+                        GameStats.shared.recordMove()
                         saveGameState()
                         checkForWin()
                         

--- a/Nintai/Models/GameStats.swift
+++ b/Nintai/Models/GameStats.swift
@@ -31,9 +31,13 @@ class GameStats: ObservableObject {
         saveStats()
     }
     
+    func recordMove() {
+        totalMoves += 1
+        saveStats()
+    }
+
     func recordGameWin(moves: Int) {
         gamesWon += 1
-        totalMoves += moves
         currentStreak += 1
         
         if bestMoves == 0 || moves < bestMoves {
@@ -48,7 +52,6 @@ class GameStats: ObservableObject {
     }
     
     func recordGameLoss(moves: Int) {
-        totalMoves += moves
         currentStreak = 0
         print("DEBUG: recordGameLoss called, moves: \(moves), games played: \(gamesPlayed), total moves: \(totalMoves)")
         saveStats()


### PR DESCRIPTION
## Summary
- keep a running total of moves
- update stats every time a move is made

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688460e5b8748322a46f352c69a179e4